### PR TITLE
Add support of package index as command target

### DIFF
--- a/bin/npack
+++ b/bin/npack
@@ -184,7 +184,7 @@ program.command('info <package>')
 
 		Steppy(
 			function() {
-				npack.resolveName({
+				npack.resolverTargetPackage({
 					target: target,
 					dir: dir
 				}, this.slot());
@@ -223,7 +223,7 @@ program.command('use <package>')
 
 		Steppy(
 			function() {
-				npack.resolveName({
+				npack.resolverTargetPackage({
 					target: target,
 					dir: dir
 				}, this.slot());
@@ -279,7 +279,7 @@ program.command('uninstall <package>')
 
 		Steppy(
 			function() {
-				npack.resolveName({
+				npack.resolverTargetPackage({
 					target: target,
 					dir: dir
 				}, this.slot());

--- a/bin/npack
+++ b/bin/npack
@@ -184,7 +184,7 @@ program.command('info <package>')
 
 		Steppy(
 			function() {
-				npack.resolverTargetPackage({
+				npack.resolveTargetPackage({
 					target: target,
 					dir: dir
 				}, this.slot());
@@ -223,7 +223,7 @@ program.command('use <package>')
 
 		Steppy(
 			function() {
-				npack.resolverTargetPackage({
+				npack.resolveTargetPackage({
 					target: target,
 					dir: dir
 				}, this.slot());
@@ -279,7 +279,7 @@ program.command('uninstall <package>')
 
 		Steppy(
 			function() {
-				npack.resolverTargetPackage({
+				npack.resolveTargetPackage({
 					target: target,
 					dir: dir
 				}, this.slot());

--- a/bin/npack
+++ b/bin/npack
@@ -179,12 +179,20 @@ program.command('current')
 program.command('info <package>')
 	.description('Print info about installed package')
 	.option('--trace', 'Show stack trace on error')
-	.action(function(name, options) {
+	.action(function(target, options) {
+		var dir = process.cwd();
+
 		Steppy(
 			function() {
+				npack.resolveName({
+					target: target,
+					dir: dir
+				}, this.slot());
+			},
+			function(err, name) {
 				npack.getInfo({
 					name: name,
-					dir: process.cwd()
+					dir: dir
 				}, this.slot());
 			},
 			function(err, pkgInfo) {
@@ -210,21 +218,28 @@ program.command('use <package>')
 		'Config file to use (default is .npackrc from cwd)',
 		defaultConfigPath
 	)
-	.action(function(name, options) {
+	.action(function(target, options) {
+		var dir = process.cwd();
+
 		Steppy(
 			function() {
+				npack.resolveName({
+					target: target,
+					dir: dir
+				}, this.slot());
+
 				npack.loadConfig({
 					path: options.config,
 					log: options.log
 				}, this.slot());
 			},
-			function(err, config) {
+			function(err, name, config) {
 				var useOptions = _(options)
 					.chain()
 					.pick('log')
 					.extend({
 						name: name,
-						dir: process.cwd(),
+						dir: dir,
 						disabledHooks: parseDisabledHooks(
 							options.disableHooks, ['use']
 						),
@@ -259,21 +274,28 @@ program.command('uninstall <package>')
 		'Config file to use (default is .npackrc from cwd)',
 		defaultConfigPath
 	)
-	.action(function(name, options) {
+	.action(function(target, options) {
+		var dir = process.cwd();
+
 		Steppy(
 			function() {
+				npack.resolveName({
+					target: target,
+					dir: dir
+				}, this.slot());
+
 				npack.loadConfig({
 					path: options.config,
 					log: options.log
 				}, this.slot());
 			},
-			function(err, config) {
+			function(err, name, config) {
 				var uninstallOptions = _(options)
 					.chain()
 					.pick('log')
 					.extend({
 						name: name,
-						dir: process.cwd(),
+						dir: dir,
 						disabledHooks: parseDisabledHooks(
 							options.disableHooks, ['uninstall']
 						),

--- a/lib/npack.js
+++ b/lib/npack.js
@@ -32,7 +32,7 @@ var createLogger = function(options) {
 	return options.log ? utilsLogger : {log: _.noop, warn: _.noop};
 };
 
-var packageIndexRegex = /\d+/;
+var packageIndexRegExp = /\d+/;
 
 exports.version = packageJson.version;
 
@@ -615,7 +615,7 @@ exports.uninstall = function(options, callback) {
 	);
 };
 
-exports.resolveName = function(options, callback) {
+exports.resolverTargetPackage = function(options, callback) {
 	Steppy(
 		function() {
 			checkOptions(options, ['target', 'dir']);
@@ -628,7 +628,7 @@ exports.resolveName = function(options, callback) {
 
 			if (packageInfo) {
 				name = packageInfo.name;
-			} else if (packageIndexRegex.test(options.target)) {
+			} else if (packageIndexRegExp.test(options.target)) {
 				var packageIndex = Number(options.target);
 
 				if (packageIndex >= packageInfos.length) {

--- a/lib/npack.js
+++ b/lib/npack.js
@@ -32,6 +32,8 @@ var createLogger = function(options) {
 	return options.log ? utilsLogger : {log: _.noop, warn: _.noop};
 };
 
+var packageIndexRegex = /\d+/;
+
 exports.version = packageJson.version;
 
 exports.loadConfig = function(options, callback) {
@@ -608,6 +610,39 @@ exports.uninstall = function(options, callback) {
 		function() {
 			logger.log('Package successfully uninstalled');
 			this.pass(null);
+		},
+		callback
+	);
+};
+
+exports.resolveName = function(options, callback) {
+	Steppy(
+		function() {
+			checkOptions(options, ['target', 'dir']);
+
+			exports.getList(_(options).pick('dir'), this.slot());
+		},
+		function(err, packageInfos) {
+			var name;
+			var packageInfo = _(packageInfos).findWhere({name: options.target});
+
+			if (packageInfo) {
+				name = packageInfo.name;
+			} else if (packageIndexRegex.test(options.target)) {
+				var packageIndex = Number(options.target);
+
+				if (packageIndex >= packageInfos.length) {
+					throw new Error('Package with index ' + packageIndex + ' is not found');
+				}
+
+				name = packageInfos[packageIndex].name;
+			}
+
+			if (!name) {
+				throw new Error('Package "' + options.target + '" is not found');
+			}
+
+			this.pass(name);
 		},
 		callback
 	);

--- a/lib/npack.js
+++ b/lib/npack.js
@@ -615,7 +615,7 @@ exports.uninstall = function(options, callback) {
 	);
 };
 
-exports.resolverTargetPackage = function(options, callback) {
+exports.resolveTargetPackage = function(options, callback) {
 	Steppy(
 		function() {
 			checkOptions(options, ['target', 'dir']);

--- a/lib/utils/logger.js
+++ b/lib/utils/logger.js
@@ -94,7 +94,7 @@ exports.writePkgsList = function(pkgInfos, options) {
 	_(pkgInfos).each(function(pkgInfo, index) {
 		if (options.info && index ) console.log('');
 
-		var str = spacesStr + pkgInfo.name;
+		var str = spacesStr + '[' + index + '] ' + pkgInfo.name;
 
 		if (pkgInfo.npm) {
 			str += ' (' + pkgInfo.npm.name + ' ' + pkgInfo.npm.version + ')';

--- a/test/resolveName.js
+++ b/test/resolveName.js
@@ -1,0 +1,122 @@
+'use strict';
+
+var Steppy = require('twostep').Steppy;
+var fse = require('fs-extra');
+var path = require('path');
+var helpers = require('./helpers');
+var npack = require('../lib/npack');
+var expect = require('expect.js');
+
+describe('.resolveName()', function() {
+	describe('should return an error', function() {
+		it('if required option `target` is not set', function(done) {
+			npack.resolveName({dir: '.'}, function(err) {
+				helpers.checkError(err, 'Option "target" is required');
+				done();
+			});
+		});
+
+		it('if required option `dir` is not set', function(done) {
+			npack.resolveName({target: 'a'}, function(err) {
+				helpers.checkError(err, 'Option "dir" is required');
+				done();
+			});
+		});
+	});
+
+	describe('switching between installed packages', function() {
+		beforeEach(function(done) {
+			fse.emptyDir(helpers.tempDir, done);
+		});
+
+		after(function(done) {
+			fse.remove(helpers.tempDir, done);
+		});
+
+		it('should be ok with package name', function(done) {
+			Steppy(
+				function() {
+					npack.install({
+						src: path.join(helpers.fixturesDir, 'simple.tar.gz'),
+						dir: helpers.tempDir
+					}, this.slot());
+				},
+				function(err, pkgInfo) {
+					this.pass(pkgInfo);
+
+					npack.resolveName({
+						target: pkgInfo.name,
+						dir: helpers.tempDir
+					}, this.slot());
+				},
+				function(err, pkgInfo, name) {
+					expect(name).equal(pkgInfo.name);
+					done();
+				}
+			);
+		});
+
+		it('should be ok with package index', function(done) {
+			Steppy(
+				function() {
+					npack.install({
+						src: path.join(helpers.fixturesDir, 'simple.tar.gz'),
+						dir: helpers.tempDir
+					}, this.slot());
+				},
+				function(err, pkgInfo) {
+					this.pass(pkgInfo);
+
+					npack.resolveName({
+						target: '0',
+						dir: helpers.tempDir
+					}, this.slot());
+				},
+				function(err, pkgInfo, name) {
+					expect(name).equal(pkgInfo.name);
+					done();
+				}
+			);
+		});
+
+		it('should fail with index out of list bound', function(done) {
+			Steppy(
+				function() {
+					npack.install({
+						src: path.join(helpers.fixturesDir, 'simple.tar.gz'),
+						dir: helpers.tempDir
+					}, this.slot());
+				},
+				function() {
+					npack.resolveName({
+						target: '1',
+						dir: helpers.tempDir
+					}, this.slot());
+				},
+				function(err) {
+					helpers.checkError(
+						err, 'Package with index 1 is not found'
+					);
+					done();
+				}
+			);
+		});
+
+		it('should fail if package not installed', function(done) {
+			Steppy(
+				function() {
+					npack.resolveName({
+						target: 'unknown',
+						dir: helpers.tempDir
+					}, this.slot());
+				},
+				function(err) {
+					helpers.checkError(
+						err, 'Package "unknown" is not found'
+					);
+					done();
+				}
+			);
+		});
+	});
+});

--- a/test/resolveTargetPackage.js
+++ b/test/resolveTargetPackage.js
@@ -7,17 +7,17 @@ var helpers = require('./helpers');
 var npack = require('../lib/npack');
 var expect = require('expect.js');
 
-describe('.resolverTargetPackage()', function() {
+describe('.resolveTargetPackage()', function() {
 	describe('should return an error', function() {
 		it('if required option `target` is not set', function(done) {
-			npack.resolverTargetPackage({dir: '.'}, function(err) {
+			npack.resolveTargetPackage({dir: '.'}, function(err) {
 				helpers.checkError(err, 'Option "target" is required');
 				done();
 			});
 		});
 
 		it('if required option `dir` is not set', function(done) {
-			npack.resolverTargetPackage({target: 'a'}, function(err) {
+			npack.resolveTargetPackage({target: 'a'}, function(err) {
 				helpers.checkError(err, 'Option "dir" is required');
 				done();
 			});
@@ -44,7 +44,7 @@ describe('.resolverTargetPackage()', function() {
 				function(err, pkgInfo) {
 					this.pass(pkgInfo);
 
-					npack.resolverTargetPackage({
+					npack.resolveTargetPackage({
 						target: pkgInfo.name,
 						dir: helpers.tempDir
 					}, this.slot());
@@ -67,7 +67,7 @@ describe('.resolverTargetPackage()', function() {
 				function(err, pkgInfo) {
 					this.pass(pkgInfo);
 
-					npack.resolverTargetPackage({
+					npack.resolveTargetPackage({
 						target: '0',
 						dir: helpers.tempDir
 					}, this.slot());
@@ -88,7 +88,7 @@ describe('.resolverTargetPackage()', function() {
 					}, this.slot());
 				},
 				function() {
-					npack.resolverTargetPackage({
+					npack.resolveTargetPackage({
 						target: '1',
 						dir: helpers.tempDir
 					}, this.slot());
@@ -105,7 +105,7 @@ describe('.resolverTargetPackage()', function() {
 		it('should fail if package not installed', function(done) {
 			Steppy(
 				function() {
-					npack.resolverTargetPackage({
+					npack.resolveTargetPackage({
 						target: 'unknown',
 						dir: helpers.tempDir
 					}, this.slot());

--- a/test/resolveTargetPackage.js
+++ b/test/resolveTargetPackage.js
@@ -7,24 +7,24 @@ var helpers = require('./helpers');
 var npack = require('../lib/npack');
 var expect = require('expect.js');
 
-describe('.resolveName()', function() {
+describe('.resolverTargetPackage()', function() {
 	describe('should return an error', function() {
 		it('if required option `target` is not set', function(done) {
-			npack.resolveName({dir: '.'}, function(err) {
+			npack.resolverTargetPackage({dir: '.'}, function(err) {
 				helpers.checkError(err, 'Option "target" is required');
 				done();
 			});
 		});
 
 		it('if required option `dir` is not set', function(done) {
-			npack.resolveName({target: 'a'}, function(err) {
+			npack.resolverTargetPackage({target: 'a'}, function(err) {
 				helpers.checkError(err, 'Option "dir" is required');
 				done();
 			});
 		});
 	});
 
-	describe('switching between installed packages', function() {
+	describe('resolving given target to package name', function() {
 		beforeEach(function(done) {
 			fse.emptyDir(helpers.tempDir, done);
 		});
@@ -44,7 +44,7 @@ describe('.resolveName()', function() {
 				function(err, pkgInfo) {
 					this.pass(pkgInfo);
 
-					npack.resolveName({
+					npack.resolverTargetPackage({
 						target: pkgInfo.name,
 						dir: helpers.tempDir
 					}, this.slot());
@@ -67,7 +67,7 @@ describe('.resolveName()', function() {
 				function(err, pkgInfo) {
 					this.pass(pkgInfo);
 
-					npack.resolveName({
+					npack.resolverTargetPackage({
 						target: '0',
 						dir: helpers.tempDir
 					}, this.slot());
@@ -88,7 +88,7 @@ describe('.resolveName()', function() {
 					}, this.slot());
 				},
 				function() {
-					npack.resolveName({
+					npack.resolverTargetPackage({
 						target: '1',
 						dir: helpers.tempDir
 					}, this.slot());
@@ -105,7 +105,7 @@ describe('.resolveName()', function() {
 		it('should fail if package not installed', function(done) {
 			Steppy(
 				function() {
-					npack.resolveName({
+					npack.resolverTargetPackage({
 						target: 'unknown',
 						dir: helpers.tempDir
 					}, this.slot());


### PR DESCRIPTION
* add ordinal index to packages list
* add method `resolveName()` which try to resolve given target to package name
* add support of package index instead of name in `use`, `info`, and `uninstall` commands