### PR TITLE
Fix relative path usage with --dir option

### DIFF
--- a/lib/utils/npm.js
+++ b/lib/utils/npm.js
@@ -4,7 +4,7 @@ var processUtils = require('./process'),
 	Steppy = require('twostep').Steppy,
 	path = require('path'),
 	url = require('url'),
-	fs = require('fs');
+	fse = require('fs-extra');
 
 exports.install = function(options, callback) {
 	processUtils.exec('npm install --production', options, callback);
@@ -46,7 +46,7 @@ exports.download = function(targetPackage, dest, options, callback) {
 
 			var packSpawn = processUtils.exec(
 				'npm pack ' + targetPackage,
-				{cwd: dir},
+				{},
 				function(err) {
 					if (err && packErrData) {
 						err.message += '\nstderr: ' + packErrData;
@@ -65,10 +65,10 @@ exports.download = function(targetPackage, dest, options, callback) {
 			});
 		},
 		function(err, dir, packOutData) {
-			var tarballName = packOutData.replace(/\n$/, '');
+			var tarballName = packOutData.trim();
 
-			fs.rename(
-				path.join(dir, tarballName),
+			fse.move(
+				path.join(process.cwd(), tarballName),
 				dest,
 				this.slot()
 			);


### PR DESCRIPTION
Download package to current directory and than move it to target directory instead of spawn `npm pack` in target directory.