### PR TITLE
add preferCi sync mode to install command

### DIFF
--- a/lib/npack.js
+++ b/lib/npack.js
@@ -33,7 +33,7 @@ var createLogger = function(options) {
 };
 
 var packageIndexRegExp = /^\d+$/;
-var availableSyncModes = ['install', 'ci'];
+var availableSyncModes = ['install', 'ci', 'preferCi'];
 
 exports.version = packageJson.version;
 
@@ -150,6 +150,38 @@ var syncByCi = function(options, callback) {
 	);
 };
 
+var syncByPreferCi = function(options, callback) {
+	var tmpPkgSubPath;
+
+	Steppy(
+		function() {
+			tmpPkgSubPath = path.join(options.tmpPkgPath, 'package');
+
+			fse.pathExists(
+				path.join(tmpPkgSubPath, 'npm-shrinkwrap.json'),
+				this.slot()
+			);
+
+			npmUtils.getNpmVersion(this.slot());
+		},
+		function(err, shrinkwrapExists, npmVersion) {
+			// `npm ci` becomes available in npm@5.7.0 and higher
+			if (
+				shrinkwrapExists &&
+				semver.gte(npmVersion, '5.7.0')
+			) {
+				npmUtils.ci({
+					cwd: tmpPkgSubPath,
+					log: options.log
+				}, this.slot());
+			} else {
+				syncByInstall(options, this.slot());
+			}
+		},
+		callback
+	);
+};
+
 exports.install = function(options, callback) {
 	options = _({}).defaults(options, {
 		nameFormat: 'timestamp',
@@ -260,18 +292,31 @@ exports.install = function(options, callback) {
 			logger.log('Sync temp package npm dependencies');
 
 			// sync node_modules
-			if (options.syncMode === 'install') {
-				syncByInstall({
-					tmpPkgPath: tmpPkgPath,
-					currentPkgPath: options.dir,
-					logger: logger,
-					log: options.log
-				}, this.slot());
-			} else if (options.syncMode === 'ci') {
-				syncByCi({
-					tmpPkgPath: tmpPkgPath,
-					log: options.log
-				}, this.slot());
+			switch (options.syncMode) {
+				case 'install':
+					syncByInstall({
+						tmpPkgPath: tmpPkgPath,
+						currentPkgPath: options.dir,
+						logger: logger,
+						log: options.log
+					}, this.slot());
+					break;
+
+				case 'ci':
+					syncByCi({
+						tmpPkgPath: tmpPkgPath,
+						log: options.log
+					}, this.slot());
+					break;
+
+				case 'preferCi':
+					syncByPreferCi({
+						tmpPkgPath: tmpPkgPath,
+						currentPkgPath: options.dir,
+						logger: logger,
+						log: options.log
+					}, this.slot());
+					break;
 			}
 
 			// remove tar.gz if exists

--- a/lib/npack.js
+++ b/lib/npack.js
@@ -162,18 +162,11 @@ var syncByPreferCi = function(options, callback) {
 				this.slot()
 			);
 
-			npmUtils.getNpmVersion(this.slot());
+			npmUtils.isNpmCiAvailabe(this.slot());
 		},
-		function(err, shrinkwrapExists, npmVersion) {
-			// `npm ci` becomes available in npm@5.7.0 and higher
-			if (
-				shrinkwrapExists &&
-				semver.gte(npmVersion, '5.7.0')
-			) {
-				npmUtils.ci({
-					cwd: tmpPkgSubPath,
-					log: options.log
-				}, this.slot());
+		function(err, shrinkwrapExists, npmCiAvailable) {
+			if (shrinkwrapExists && npmCiAvailable) {
+				syncByCi(options, this.slot());
 			} else {
 				syncByInstall(options, this.slot());
 			}

--- a/lib/utils/npm.js
+++ b/lib/utils/npm.js
@@ -90,3 +90,37 @@ exports.download = function(targetPackage, dest, options, callback) {
 		callback
 	);
 };
+
+exports.getNpmVersion = function(callback) {
+	Steppy(
+		function() {
+			var npmVersionSlot = this.slot();
+			var npmVersionOutData = '';
+			var npmVersionErrData = '';
+
+			var npmVersionSpawn = processUtils.exec(
+				'npm --version',
+				{},
+				function(err) {
+					if (err && npmVersionErrData) {
+						err.message += '\nstderr: ' + npmVersionErrData;
+					}
+
+					npmVersionSlot(err, npmVersionOutData);
+				}
+			);
+
+			npmVersionSpawn.stdout.on('data', function(data) {
+				npmVersionOutData += data;
+			});
+
+			npmVersionSpawn.stderr.on('data', function(data) {
+				npmVersionErrData += data;
+			});
+		},
+		function(err, npmVersionData) {
+			this.pass(npmVersionData.trim());
+		},
+		callback
+	);
+};

--- a/lib/utils/npm.js
+++ b/lib/utils/npm.js
@@ -91,36 +91,21 @@ exports.download = function(targetPackage, dest, options, callback) {
 	);
 };
 
-exports.getNpmVersion = function(callback) {
+exports.isNpmCiAvailabe = function(callback) {
 	Steppy(
 		function() {
-			var npmVersionSlot = this.slot();
-			var npmVersionOutData = '';
-			var npmVersionErrData = '';
-
-			var npmVersionSpawn = processUtils.exec(
-				'npm --version',
+			processUtils.exec(
+				'npm ci --help',
 				{},
-				function(err) {
-					if (err && npmVersionErrData) {
-						err.message += '\nstderr: ' + npmVersionErrData;
-					}
-
-					npmVersionSlot(err, npmVersionOutData);
-				}
+				this.slot()
 			);
-
-			npmVersionSpawn.stdout.on('data', function(data) {
-				npmVersionOutData += data;
-			});
-
-			npmVersionSpawn.stderr.on('data', function(data) {
-				npmVersionErrData += data;
-			});
 		},
-		function(err, npmVersionData) {
-			this.pass(npmVersionData.trim());
-		},
-		callback
+		function(err) {
+			if (err && !err.exitCode) {
+				return callback(err);
+			}
+
+			callback(null, Boolean(!err || err.exitCode === 0));
+		}
 	);
 };

--- a/lib/utils/process.js
+++ b/lib/utils/process.js
@@ -32,6 +32,7 @@ exports.exec = function(cmd, options, callback) {
 				err = new Error(
 					'Command "' + cmd + '" failed with exit code: ' + code
 				);
+				err.exitCode = code;
 			}
 
 			callback(err);

--- a/test/install.js
+++ b/test/install.js
@@ -195,7 +195,7 @@ describe('.install()', function() {
 					helpers.checkError(
 						err,
 						'Expect sync mode "invalidSyncMode" to be ' +
-						'one of "install", "ci"'
+						'one of "install", "ci", "preferCi"'
 					);
 
 					done();
@@ -253,7 +253,7 @@ describe('.install()', function() {
 		});
 	});
 
-	describe.only('with preferCi sync mode', function() {
+	describe('with preferCi sync mode', function() {
 		beforeEach(function(done) {
 			fse.emptyDir(helpers.tempDir, done);
 		});

--- a/test/install.js
+++ b/test/install.js
@@ -253,6 +253,48 @@ describe('.install()', function() {
 		});
 	});
 
+	describe.only('with preferCi sync mode', function() {
+		beforeEach(function(done) {
+			fse.emptyDir(helpers.tempDir, done);
+		});
+
+		afterEach(function(done) {
+			fse.remove(helpers.tempDir, done);
+		});
+
+		it('should be ok with shrinkwrap in package', function(done) {
+			Steppy(
+				function() {
+					npack.install({
+						src: path.join(helpers.fixturesDir, 'shrinkwrap.tar.gz'),
+						dir: helpers.tempDir,
+						syncMode: 'preferCi'
+					}, this.slot());
+				},
+				function(err, pkgInfo) {
+					helpers.checkPkgExists(pkgInfo, true, this.slot());
+				},
+				done
+			);
+		});
+
+		it('should be ok without shrinkwrap in package', function(done) {
+			Steppy(
+				function() {
+					npack.install({
+						src: path.join(helpers.fixturesDir, 'simple.tar.gz'),
+						dir: helpers.tempDir,
+						syncMode: 'preferCi'
+					}, this.slot());
+				},
+				function(err, pkgInfo) {
+					helpers.checkPkgExists(pkgInfo, true, this.slot());
+				},
+				done
+			);
+		});
+	});
+
 	describe('hooks', function() {
 		beforeEach(function(done) {
 			fse.emptyDir(helpers.tempDir, done);


### PR DESCRIPTION
Аdd preferCi sync mode to install command.
It uses `npm ci` if npm support it and shrinkwrap exists, otherwise works by default `install` mode flow