### PR TITLE
Add close event signal handling to spawn helper in process utils

### DIFF
--- a/lib/utils/process.js
+++ b/lib/utils/process.js
@@ -25,14 +25,22 @@ exports.exec = function(cmd, options, callback) {
 	}
 
 	return spawn(shell, args, spawnOptions)
-		.on('close', function(code) {
+		.on('close', function(code, signal) {
 			var err;
 
 			if (code) {
 				err = new Error(
 					'Command "' + cmd + '" failed with exit code: ' + code
 				);
+			} else if (signal) {
+				err = new Error(
+					'Command "' + cmd + '" killed with signal: ' + signal
+				);
+			}
+
+			if (err) {
 				err.exitCode = code;
+				err.signal = signal;
 			}
 
 			callback(err);

--- a/lib/utils/process.js
+++ b/lib/utils/process.js
@@ -34,7 +34,7 @@ exports.exec = function(cmd, options, callback) {
 				);
 			} else if (signal) {
 				err = new Error(
-					'Command "' + cmd + '" killed with signal: ' + signal
+					'Command "' + cmd + '" terminated with signal: ' + signal
 				);
 			}
 


### PR DESCRIPTION
Handle `signal` in `close` event listener in `lib/utils/process.js` `spawn` helper.