### PR TITLE
Add optional arguments to run command

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,6 +56,16 @@ To uninstall installed package run:
 $ npack uninstall <package_name>
 ```
 
+### Execute "npm run" task from current package
+
+To execute npm script with optional agruments run:
+
+```bash
+$ npack run <script_name>
+$ npack run <script_name> arg_1 arg_2
+$ npack run <script_name> -- arg_1 --with flag
+```
+
 ## License
 
 [MIT](./LICENSE)

--- a/bin/npack
+++ b/bin/npack
@@ -8,6 +8,7 @@ var program = require('commander'),
 	Steppy = require('twostep').Steppy,
 	read = require('read'),
 	processUtils = require('../lib/utils/process'),
+	shellQuote = require('shell-quote').quote,
 	logger = require('../lib/utils/logger'),
 	fsUtils = require('../lib/utils/fs'),
 	path = require('path'),
@@ -417,7 +418,7 @@ program.command('clean')
 		);
 	});
 
-program.command('run [script]')
+program.command('run [script] [args...]')
 	.description('Execute "npm run" task from current package')
 	.option('-L, --no-log', 'Disable detailed log')
 	.option('--trace', 'Show stack trace on error')
@@ -432,7 +433,7 @@ program.command('run [script]')
 		resolveDirPath,
 		defaultDirPath
 	)
-	.action(function(script, options) {
+	.action(function(script, args, options) {
 		Steppy(
 			function() {
 				fsUtils.checkDirExists({
@@ -477,7 +478,13 @@ program.command('run [script]')
 				if (_(pkgInfo.scripts).has(script)) {
 					logger.log('Execute script "npm run %s"', script);
 
-					processUtils.execScript('npm run --silent ' + script, {
+					var cmd = 'npm run --silent ' + script;
+
+					if (!_(args).isEmpty()) {
+						cmd += ' -- ' + shellQuote(args);
+					}
+
+					processUtils.execScript(cmd, {
 						cwd: pkgInfo.path,
 						dir: options.dir,
 						log: options.log,

--- a/package.json
+++ b/package.json
@@ -45,7 +45,7 @@
     "npm-package-arg": "6.0.0",
     "read": "1.0.7",
     "semver": "5.1.0",
-    "shell-quote": "^1.6.1",
+    "shell-quote": "1.7.1",
     "tar": "2.2.1",
     "twostep": "0.4.1",
     "underscore": "1.8.3"

--- a/package.json
+++ b/package.json
@@ -45,6 +45,7 @@
     "npm-package-arg": "6.0.0",
     "read": "1.0.7",
     "semver": "5.1.0",
+    "shell-quote": "^1.6.1",
     "tar": "2.2.1",
     "twostep": "0.4.1",
     "underscore": "1.8.3"


### PR DESCRIPTION
Arguments could be passed both with and without `--` special argument:

```
npack run scriptName arg1 arg2
```

```
npack run scriptName -- arg1 arg2
```

But CLI flags must be escaped with `--`:

```
npack run scriptName -- arg1 --foo bar
```

otherwise `commander` will try to parse them as `run` command oprions and throw an error:

```
npack run scriptName arg1 --foo bar
# error: unknown option `--foo'
```

Since `--` role is not self-explanatory, it may be a good idea to document this behavior somewhere.