### PR TITLE
Update deps to fix vulnerabilities

### DIFF
--- a/lib/utils/fs.js
+++ b/lib/utils/fs.js
@@ -1,7 +1,6 @@
 'use strict';
 
 var fse = require('fs-extra'),
-	mkdirp = require('mkdirp'),
 	tar = require('tar'),
 	path = require('path'),
 	_ = require('underscore'),
@@ -10,7 +9,7 @@ var fse = require('fs-extra'),
 exports.extract = function(src, dest, callback) {
 	Steppy(
 		function() {
-			mkdirp(dest, this.slot());
+			fse.ensureDir(dest, this.slot());
 		},
 		function() {
 			tar.extract({file: src, cwd: dest}, this.slot());

--- a/lib/utils/fs.js
+++ b/lib/utils/fs.js
@@ -1,23 +1,22 @@
 'use strict';
 
 var fse = require('fs-extra'),
-	multipipe = require('multipipe'),
-	zlib = require('zlib'),
+	mkdirp = require('mkdirp'),
 	tar = require('tar'),
 	path = require('path'),
 	_ = require('underscore'),
 	Steppy = require('twostep').Steppy;
 
 exports.extract = function(src, dest, callback) {
-	var srcStream = fse.createReadStream(src);
-	var gunzipStream = zlib.createGunzip();
-	var tarStream = tar.Extract({path: dest});
-
-	tarStream.on('end', callback);
-
-	multipipe(srcStream, gunzipStream, tarStream, function(err) {
-		if (err) callback(err);
-	});
+	Steppy(
+		function() {
+			mkdirp(dest, this.slot());
+		},
+		function() {
+			tar.extract({file: src, cwd: dest}, this.slot());
+		},
+		callback
+	);
 };
 
 exports.checkDirExists = function(options, callback) {

--- a/package.json
+++ b/package.json
@@ -40,13 +40,13 @@
     "colors": "1.3.3",
     "commander": "3.0.0",
     "fs-extra": "8.1.0",
+    "mkdirp": "0.5.1",
     "moment": "2.24.0",
-    "multipipe": "3.0.1",
     "npm-package-arg": "6.1.0",
     "read": "1.0.7",
     "semver": "6.3.0",
     "shell-quote": "1.7.1",
-    "tar": "2.2.1",
+    "tar": "4.4.10",
     "twostep": "0.4.2",
     "underscore": "1.9.1"
   }

--- a/package.json
+++ b/package.json
@@ -40,7 +40,6 @@
     "colors": "1.3.3",
     "commander": "3.0.0",
     "fs-extra": "8.1.0",
-    "mkdirp": "0.5.1",
     "moment": "2.24.0",
     "npm-package-arg": "6.1.0",
     "read": "1.0.7",

--- a/package.json
+++ b/package.json
@@ -30,24 +30,24 @@
   },
   "homepage": "https://github.com/2do2go/npack",
   "devDependencies": {
-    "chai": "3.5.0",
+    "chai": "4.2.0",
     "expect.js": "0.3.1",
-    "jshint": "2.4.4",
-    "mocha": "2.4.5",
-    "node-static": "0.7.10"
+    "jshint": "2.10.2",
+    "mocha": "6.2.0",
+    "node-static": "0.7.11"
   },
   "dependencies": {
-    "colors": "1.1.2",
-    "commander": "2.9.0",
-    "fs-extra": "4.0.2",
-    "moment": "2.11.2",
-    "multipipe": "0.3.0",
-    "npm-package-arg": "6.0.0",
+    "colors": "1.3.3",
+    "commander": "3.0.0",
+    "fs-extra": "8.1.0",
+    "moment": "2.24.0",
+    "multipipe": "3.0.1",
+    "npm-package-arg": "6.1.0",
     "read": "1.0.7",
-    "semver": "5.1.0",
+    "semver": "6.3.0",
     "shell-quote": "1.7.1",
     "tar": "2.2.1",
-    "twostep": "0.4.1",
-    "underscore": "1.8.3"
+    "twostep": "0.4.2",
+    "underscore": "1.9.1"
   }
 }

--- a/package.json
+++ b/package.json
@@ -33,13 +33,13 @@
     "chai": "4.2.0",
     "expect.js": "0.3.1",
     "jshint": "2.10.2",
-    "mocha": "6.2.0",
+    "mocha": "5.2.0",
     "node-static": "0.7.11"
   },
   "dependencies": {
     "colors": "1.3.3",
     "commander": "3.0.0",
-    "fs-extra": "8.1.0",
+    "fs-extra": "5.0.0",
     "moment": "2.24.0",
     "npm-package-arg": "6.1.1",
     "read": "1.0.7",

--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
     "commander": "3.0.0",
     "fs-extra": "8.1.0",
     "moment": "2.24.0",
-    "npm-package-arg": "6.1.0",
+    "npm-package-arg": "6.1.1",
     "read": "1.0.7",
     "semver": "6.3.0",
     "shell-quote": "1.7.1",


### PR DESCRIPTION
`npm audit` shows some critical vulnerabilities because because all dependencies are very outdated.

This PR updates all dependencies to their latest versions and introduces some minor patches to fix `tar` after braking major update.

I've removed `multipipe` dependency since latest `tar` version handles the whole extraction process including automatic unzipping of zipped tarballs.
